### PR TITLE
Fake table.c.values() type: List[Column]

### DIFF
--- a/sqlacodegen/codegen.py
+++ b/sqlacodegen/codegen.py
@@ -436,6 +436,10 @@ class CodeGenerator(object):
         else:
             self.collector.add_literal_import('sqlalchemy.ext.declarative', 'declarative_base')
 
+        # imports for *.c.values()
+        self.collector.add_literal_import('typing', 'List')
+        self.collector.add_literal_import('abc', 'abstractmethod')
+
     def create_inflect_engine(self):
         if self.noinflect:
             return _DummyInflectEngine()
@@ -633,6 +637,10 @@ class CodeGenerator(object):
         )
         --------- Output:
         class _AccountColumns:
+            @abstractmethod
+            def values(self) -> List[Column]:
+                pass
+
             id: Column
             credential_id: Column
             vendor_id: Column
@@ -647,7 +655,13 @@ class CodeGenerator(object):
         columns_type = f'_{camel_case_name}Columns'
         proxy_type = f'_{camel_case_name}Table'
 
-        rendered = f'class {columns_type}:\n'
+        rendered = dedent(f'''\
+        class {columns_type}:
+            @abstractmethod
+            def values(self) -> List[Column]:
+                pass
+
+        ''')
 
         for column in model.table.columns:
             rendered += f'{self.indentation}{column.name}: Column\n'


### PR DESCRIPTION
https://app.clubhouse.io/alloytech/story/40743/typing-for-table-c-values-in-schema-py

This adds `.values() -> List[Column]` to `table.c`